### PR TITLE
fix favicon for assets pipeline

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <%= csrf_meta_tags %>
     <%= action_cable_meta_tag %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <link href="/assets/squarelogo.png" rel="shortcut icon" type="x-icon" />
+    <%= favicon_link_tag 'squarelogo.png' %>
   </head>
   <body>
     <%= render 'shared/navbar' %>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/171245/29901606-8f401806-8dbe-11e7-9a6f-5c3ea8408043.png)


in production environment, assets should be served through assets pipeline (see above screenshot with the random character tail)